### PR TITLE
Avoid error when piping into node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ export async function exec(bail) {
 
 	isRunning = false;
 	write('\n  Total:     ' + total);
-	write((code ? kleur.red : kleur.green)('\n  Passed:    ' + done));
+	write((code ? kleur.red : kleur.green).call(kleur, '\n  Passed:    ' + done));
 	write('\n  Skipped:   ' + (skips ? kleur.yellow(skips) : skips));
 	write('\n  Duration:  ' + timer() + '\n\n');
 


### PR DESCRIPTION
When piping bundled code into node with stdin, uvu was throwing an error here:

```js
      !!~this.has.indexOf(open) || (this.has.push(open), this.keys.push(blk));
                  ^

TypeError: this.has.indexOf is not a function
    at [stdin]:174:19
    at Timeout.exec [as _onTimeout] ([stdin]:1038:53)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

changing the line so that there is definitely a `this` seems to fix it.